### PR TITLE
Fix IllegalArgumentException for the illegal completion

### DIFF
--- a/src/main/java/net/unit8/erebus/tryartifact/command/TryArtifactCommandRegister.java
+++ b/src/main/java/net/unit8/erebus/tryartifact/command/TryArtifactCommandRegister.java
@@ -56,7 +56,7 @@ public class TryArtifactCommandRegister {
                                 .map(a -> new SourceCodeAnalysis.Suggestion(a.toString(), false))
                                 .forEach(results::add);
                         anchor[0] = 0; // code.length();
-                    } catch (IOException ignore) {
+                    } catch (IOException | IllegalArgumentException ignore) {
 
                     }
                     return results;

--- a/src/test/java/net/unit8/erebus/tryartifact/tool/ResolveCommandTest.java
+++ b/src/test/java/net/unit8/erebus/tryartifact/tool/ResolveCommandTest.java
@@ -10,8 +10,8 @@ import org.testng.annotations.Test;
 public class ResolveCommandTest extends TryArtifactTesting {
     public void testBadArtifactCoordinate() {
         test(
-                a -> assertCommand(a, "/resolve bad", "|  Bad artifact coordinates bad, expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>\n")
+                a -> assertCommand(a, "/resolve bad", "|  Bad artifact coordinates bad, expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>\n"),
+                a -> assertCompletion(a, "/resolve hoge:hoge:hoge:hoge:hoge:hoge|", true)
         );
     }
-
 }


### PR DESCRIPTION
Fix IAE for illegal completion with test:
```
-> /reso hoge:hoge:hoge:hoge:hoge:hoge
Exception in thread "main" java.lang.IllegalArgumentException: Bad artifact coordinates hoge:hoge:hoge:hoge:hoge:hoge, expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>
	at org.eclipse.aether.artifact.DefaultArtifact.<init>(DefaultArtifact.java:68)
	at org.eclipse.aether.artifact.DefaultArtifact.<init>(DefaultArtifact.java:51)
	at net.unit8.erebus.ArtifactSearcher.searchIncremental(ArtifactSearcher.java:98)
	at net.unit8.erebus.tryartifact.command.TryArtifactCommandRegister.lambda$register$3(TryArtifactCommandRegister.java:52)
	at net.unit8.erebus.tryartifact.tool.TryJShellTool.commandCompletionSuggestions(TryJShellTool.java:1092)
	at net.unit8.erebus.tryartifact.tool.ConsoleIOContext$2.complete(ConsoleIOContext.java:91)
	at jline.console.ConsoleReader.complete(ConsoleReader.java:3261)
	at jline.console.ConsoleReader.readLine(ConsoleReader.java:2621)
	at jline.console.ConsoleReader.readLine(ConsoleReader.java:2269)
	at net.unit8.erebus.tryartifact.tool.ConsoleIOContext.readLine(ConsoleIOContext.java:160)
	at net.unit8.erebus.tryartifact.tool.TryJShellTool.run(TryJShellTool.java:572)
	at net.unit8.erebus.tryartifact.tool.TryJShellTool.start(TryJShellTool.java:389)
	at net.unit8.erebus.tryartifact.tool.TryJShellTool.start(TryJShellTool.java:362)
	at net.unit8.erebus.TryArtifact.main(TryArtifact.java:17)
```