### PR TITLE
fix: compile sealed hierarchies with later-declared subtypes in batch mode (#17)

### DIFF
--- a/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
+++ b/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
@@ -571,12 +571,12 @@ public class JetShellTool {
 
     // --- Sealed-type deferral helpers (Issue #17) ---
 
-    // Anchored type-declaration matcher: leading annotations/modifiers, then the
-    // kind keyword (group 1) and the declared name (group 2). Anchoring to the
-    // start avoids matching keywords that appear inside string literals or comments.
+    // Anchored type-declaration matcher: leading modifiers, then the kind keyword
+    // (group 1) and the declared name (group 2). Annotations are removed by
+    // stripAnnotations before matching, and anchoring to the start avoids matching
+    // keywords that appear inside string literals or comments.
     private static final java.util.regex.Pattern TYPE_DECL = java.util.regex.Pattern.compile(
-            "^\\s*(?:@[\\w.]+(?:\\s*\\([^)]*\\))?\\s+"
-            + "|(?:public|protected|private|abstract|static|final|strictfp|sealed|non-sealed)\\s+)*"
+            "^\\s*(?:(?:public|protected|private|abstract|static|final|strictfp|sealed|non-sealed)\\s+)*"
             + "(class|interface|record|enum)\\s+([A-Za-z_$][\\w$]*)");
     // `sealed` as a modifier -- the negative lookbehind excludes the `non-sealed` keyword.
     private static final java.util.regex.Pattern SEALED_MOD = java.util.regex.Pattern.compile("(?<!-)\\bsealed\\b");
@@ -592,7 +592,7 @@ public class JetShellTool {
     private static String declHeader(String source) {
         int brace = bodyBraceIndex(source);
         String prefix = brace >= 0 ? source.substring(0, brace) : source;
-        return stripComments(prefix);
+        return stripAnnotations(stripComments(prefix));
     }
 
     // Returns the declared type name if the snippet is a `sealed` interface/class
@@ -744,8 +744,10 @@ public class JetShellTool {
         return sb.toString();
     }
 
-    // Index of the first `{` that is real code -- outside comments and string, char
-    // and text-block literals -- or -1 if there is none.
+    // Index of the first `{` that is the type body -- outside comments, string/char/
+    // text-block literals, and parenthesised groups (record components and
+    // annotation arguments, whose own braces must not be mistaken for the body) --
+    // or -1 if there is none.
     private static int bodyBraceIndex(String src) {
         int i = 0;
         int n = src.length();
@@ -753,6 +755,8 @@ public class JetShellTool {
             char c = src.charAt(i);
             if (c == '{') {
                 return i;
+            } else if (c == '(') {
+                i = skipParens(src, i);
             } else if (c == '/' && i + 1 < n && src.charAt(i + 1) == '/') {
                 i += 2;
                 while (i < n && src.charAt(i) != '\n') {
@@ -771,11 +775,7 @@ public class JetShellTool {
                 }
                 i += 3;
             } else if (c == '"' || c == '\'') {
-                i++;
-                while (i < n && src.charAt(i) != c) {
-                    i += (src.charAt(i) == '\\' && i + 1 < n) ? 2 : 1;
-                }
-                i++;
+                i = skipQuoted(src, i);
             } else {
                 i++;
             }
@@ -786,6 +786,76 @@ public class JetShellTool {
     private static boolean isTextBlockStart(String src, int i) {
         return i + 2 < src.length()
                 && src.charAt(i) == '"' && src.charAt(i + 1) == '"' && src.charAt(i + 2) == '"';
+    }
+
+    // Given the index of an opening quote, returns the index just past the closing
+    // quote (escapes respected). Used to skip string and char literals.
+    private static int skipQuoted(String src, int open) {
+        char q = src.charAt(open);
+        int i = open + 1;
+        int n = src.length();
+        while (i < n && src.charAt(i) != q) {
+            i += (src.charAt(i) == '\\' && i + 1 < n) ? 2 : 1;
+        }
+        return i < n ? i + 1 : i;
+    }
+
+    // Given the index of an opening '(', returns the index just past the matching
+    // ')', tracking nested parens and skipping string/char literals (so an arg such
+    // as ")" or {"a"} is consumed correctly). Returns the length if unbalanced.
+    private static int skipParens(String src, int open) {
+        int depth = 0;
+        int i = open;
+        int n = src.length();
+        while (i < n) {
+            char c = src.charAt(i);
+            if (c == '"' || c == '\'') {
+                i = skipQuoted(src, i);
+            } else if (c == '(') {
+                depth++;
+                i++;
+            } else if (c == ')') {
+                depth--;
+                i++;
+                if (depth == 0) {
+                    return i;
+                }
+            } else {
+                i++;
+            }
+        }
+        return n;
+    }
+
+    // Removes annotations (@Name and @Name(...)) from a declaration header so the
+    // start-anchored matcher sees only modifiers and the type keyword. The argument
+    // list is skipped with string-aware paren balancing, so args like ")" or {"a"}
+    // are consumed correctly.
+    private static String stripAnnotations(String header) {
+        StringBuilder sb = new StringBuilder(header.length());
+        int i = 0;
+        int n = header.length();
+        while (i < n) {
+            char c = header.charAt(i);
+            if (c == '@') {
+                i++;
+                while (i < n && (Character.isJavaIdentifierPart(header.charAt(i)) || header.charAt(i) == '.')) {
+                    i++;
+                }
+                int j = i;
+                while (j < n && Character.isWhitespace(header.charAt(j))) {
+                    j++;
+                }
+                if (j < n && header.charAt(j) == '(') {
+                    i = skipParens(header, j);
+                }
+                sb.append(' ');
+            } else {
+                sb.append(c);
+                i++;
+            }
+        }
+        return sb.toString();
     }
 
     private boolean handleEvent(SnippetEvent ste) {
@@ -986,10 +1056,13 @@ public class JetShellTool {
 
     // --- Command processing ---
 
-    // Commands that neither read nor replay snippet state. For these we leave a
-    // deferred sealed-type hierarchy pending so the user can keep declaring its
-    // subtypes; every other command finalises the hierarchy first (it may observe
-    // the resulting snippets). See Issue #17.
+    // Commands that are safe to run without first finalising a pending sealed-type
+    // hierarchy: they do not observe the deferred snippet declarations, so we leave
+    // the hierarchy pending and let the user keep declaring its subtypes. (Some,
+    // like /doc and /source, do read imports/classpath via getState(), but not the
+    // pending declarations.) Every other command finalises the hierarchy first,
+    // since it may list, save, replay or otherwise observe the resulting snippets.
+    // See Issue #17.
     private static final Set<String> NON_STATE_COMMANDS =
             Set.of("/help", "/classpath", "/resolve", "/deps", "/doc", "/source");
 

--- a/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
+++ b/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
@@ -473,9 +473,9 @@ public class JetShellTool {
                 pendingSubtypeNames.add(subtypeName);
                 return false;
             }
-            if (isBlankOrCommentOnly(source)) {
-                // A comment or blank snippet between the sealed type and its subtypes
-                // (as split from a whole file) must not finalise the hierarchy.
+            if (isBlankOrCommentOnly(source) || isImport(source)) {
+                // A comment, blank or import snippet between the sealed type and its
+                // subtypes must not finalise the hierarchy; evaluate it and keep going.
                 return processCompleteSource(source);
             }
             // The contiguous hierarchy ended; finalise this one block, then route the
@@ -584,14 +584,15 @@ public class JetShellTool {
     private static final java.util.regex.Pattern SUPERTYPE_KW =
             java.util.regex.Pattern.compile("\\b(?:extends|implements)\\b");
 
-    // The declaration prefix (before the body), with comments removed first so a
-    // leading comment (which analyzeCompletion prepends to the following snippet)
-    // does not defeat the start-anchored declaration matcher, and so a brace inside
-    // a comment is not mistaken for the body.
+    // The declaration prefix (before the body). The body brace is located while
+    // skipping comments and string literals (so a brace inside either is not taken
+    // for the body), then comments are removed so a leading comment -- which
+    // analyzeCompletion prepends to the following snippet -- does not defeat the
+    // start-anchored declaration matcher.
     private static String declHeader(String source) {
-        String s = stripComments(source);
-        int brace = s.indexOf('{');
-        return brace >= 0 ? s.substring(0, brace) : s;
+        int brace = bodyBraceIndex(source);
+        String prefix = brace >= 0 ? source.substring(0, brace) : source;
+        return stripComments(prefix);
     }
 
     // Returns the declared type name if the snippet is a `sealed` interface/class
@@ -623,12 +624,14 @@ public class JetShellTool {
         if (!decl.find()) {
             return null;
         }
-        java.util.regex.Matcher kw = SUPERTYPE_KW.matcher(header.substring(decl.end()));
+        // Strip generics FIRST so an `extends` inside a type-parameter bound
+        // (e.g. `class Registry<T extends Shape>`) is not mistaken for a supertype.
+        String afterName = stripGenerics(header.substring(decl.end()));
+        java.util.regex.Matcher kw = SUPERTYPE_KW.matcher(afterName);
         if (!kw.find()) {
             return null;
         }
-        String supertypes = stripGenerics(header.substring(decl.end()).substring(kw.start()));
-        return mentionsUnqualified(supertypes, superName) ? decl.group(2) : null;
+        return mentionsUnqualified(afterName.substring(kw.start()), superName) ? decl.group(2) : null;
     }
 
     // Removes the contents of balanced angle-bracket groups (generic arguments).
@@ -650,9 +653,10 @@ public class JetShellTool {
         return sb.toString();
     }
 
-    // Inserts `permits A, B, ...` immediately before the type body.
+    // Inserts `permits A, B, ...` immediately before the type body. The body brace
+    // is located while skipping comments and string literals.
     private static String injectPermits(String header, List<String> subtypeNames) {
-        int brace = header.indexOf('{');
+        int brace = bodyBraceIndex(header);
         if (brace < 0) {
             return header;
         }
@@ -675,6 +679,19 @@ public class JetShellTool {
         return stripComments(source).isBlank();
     }
 
+    private static final java.util.regex.Pattern IMPORT_STMT =
+            java.util.regex.Pattern.compile("^\\s*import\\b");
+
+    // True if the snippet is an import statement. Imports are order-independent and,
+    // unlike in a single .java file, JShell allows them anywhere, so an interleaved
+    // import must stay transparent to a pending sealed hierarchy.
+    private static boolean isImport(String source) {
+        return IMPORT_STMT.matcher(stripComments(source)).find();
+    }
+
+    // Removes line and block comments, while preserving string, char and text-block
+    // literals verbatim -- so a `//` or `/*` inside a literal is not mistaken for a
+    // comment, and a literal such as "sealed interface X" is not lost.
     private static String stripComments(String src) {
         StringBuilder sb = new StringBuilder(src.length());
         int i = 0;
@@ -682,6 +699,7 @@ public class JetShellTool {
         while (i < n) {
             char c = src.charAt(i);
             if (c == '/' && i + 1 < n && src.charAt(i + 1) == '/') {
+                i += 2;
                 while (i < n && src.charAt(i) != '\n') {
                     i++;
                 }
@@ -691,12 +709,83 @@ public class JetShellTool {
                     i++;
                 }
                 i += 2;
+            } else if (isTextBlockStart(src, i)) {
+                sb.append("\"\"\"");
+                i += 3;
+                while (i < n && !isTextBlockStart(src, i)) {
+                    sb.append(src.charAt(i));
+                    i++;
+                }
+                if (i < n) {
+                    sb.append("\"\"\"");
+                    i += 3;
+                }
+            } else if (c == '"' || c == '\'') {
+                sb.append(c);
+                i++;
+                while (i < n && src.charAt(i) != c) {
+                    sb.append(src.charAt(i));
+                    if (src.charAt(i) == '\\' && i + 1 < n) {
+                        sb.append(src.charAt(i + 1));
+                        i += 2;
+                    } else {
+                        i++;
+                    }
+                }
+                if (i < n) {
+                    sb.append(c);
+                    i++;
+                }
             } else {
                 sb.append(c);
                 i++;
             }
         }
         return sb.toString();
+    }
+
+    // Index of the first `{` that is real code -- outside comments and string, char
+    // and text-block literals -- or -1 if there is none.
+    private static int bodyBraceIndex(String src) {
+        int i = 0;
+        int n = src.length();
+        while (i < n) {
+            char c = src.charAt(i);
+            if (c == '{') {
+                return i;
+            } else if (c == '/' && i + 1 < n && src.charAt(i + 1) == '/') {
+                i += 2;
+                while (i < n && src.charAt(i) != '\n') {
+                    i++;
+                }
+            } else if (c == '/' && i + 1 < n && src.charAt(i + 1) == '*') {
+                i += 2;
+                while (i + 1 < n && !(src.charAt(i) == '*' && src.charAt(i + 1) == '/')) {
+                    i++;
+                }
+                i += 2;
+            } else if (isTextBlockStart(src, i)) {
+                i += 3;
+                while (i < n && !isTextBlockStart(src, i)) {
+                    i++;
+                }
+                i += 3;
+            } else if (c == '"' || c == '\'') {
+                i++;
+                while (i < n && src.charAt(i) != c) {
+                    i += (src.charAt(i) == '\\' && i + 1 < n) ? 2 : 1;
+                }
+                i++;
+            } else {
+                i++;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean isTextBlockStart(String src, int i) {
+        return i + 2 < src.length()
+                && src.charAt(i) == '"' && src.charAt(i + 1) == '"' && src.charAt(i + 2) == '"';
     }
 
     private boolean handleEvent(SnippetEvent ste) {

--- a/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
+++ b/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
@@ -473,6 +473,11 @@ public class JetShellTool {
                 pendingSubtypeNames.add(subtypeName);
                 return false;
             }
+            if (isBlankOrCommentOnly(source)) {
+                // A comment or blank snippet between the sealed type and its subtypes
+                // (as split from a whole file) must not finalise the hierarchy.
+                return processCompleteSource(source);
+            }
             // The contiguous hierarchy ended; finalise this one block, then route the
             // snippet afresh -- it may open a new (possibly nested) sealed hierarchy,
             // which subsequent snippets will feed. Single-level flush here so a nested
@@ -579,9 +584,14 @@ public class JetShellTool {
     private static final java.util.regex.Pattern SUPERTYPE_KW =
             java.util.regex.Pattern.compile("\\b(?:extends|implements)\\b");
 
+    // The declaration prefix (before the body), with comments removed first so a
+    // leading comment (which analyzeCompletion prepends to the following snippet)
+    // does not defeat the start-anchored declaration matcher, and so a brace inside
+    // a comment is not mistaken for the body.
     private static String declHeader(String source) {
-        int brace = source.indexOf('{');
-        return brace >= 0 ? source.substring(0, brace) : source;
+        String s = stripComments(source);
+        int brace = s.indexOf('{');
+        return brace >= 0 ? s.substring(0, brace) : s;
     }
 
     // Returns the declared type name if the snippet is a `sealed` interface/class
@@ -618,7 +628,7 @@ public class JetShellTool {
             return null;
         }
         String supertypes = stripGenerics(header.substring(decl.end()).substring(kw.start()));
-        return containsWord(supertypes, superName) ? decl.group(2) : null;
+        return mentionsUnqualified(supertypes, superName) ? decl.group(2) : null;
     }
 
     // Removes the contents of balanced angle-bracket groups (generic arguments).
@@ -651,9 +661,42 @@ public class JetShellTool {
         return beforeBody + " permits " + String.join(", ", subtypeNames) + " " + body;
     }
 
-    private static boolean containsWord(String text, String word) {
-        return java.util.regex.Pattern.compile("\\b" + java.util.regex.Pattern.quote(word) + "\\b")
+    // True if `word` appears in `text` as an unqualified type reference -- a whole
+    // word not preceded by a dot, so a qualified name like java.rmi.Remote does not
+    // count as a reference to a local `Remote`.
+    private static boolean mentionsUnqualified(String text, String word) {
+        return java.util.regex.Pattern.compile("(?<![.\\w$])" + java.util.regex.Pattern.quote(word) + "\\b")
                 .matcher(text).find();
+    }
+
+    // True if the snippet contains nothing but comments and whitespace, so it must
+    // be transparent to a pending sealed hierarchy rather than finalising it.
+    private static boolean isBlankOrCommentOnly(String source) {
+        return stripComments(source).isBlank();
+    }
+
+    private static String stripComments(String src) {
+        StringBuilder sb = new StringBuilder(src.length());
+        int i = 0;
+        int n = src.length();
+        while (i < n) {
+            char c = src.charAt(i);
+            if (c == '/' && i + 1 < n && src.charAt(i + 1) == '/') {
+                while (i < n && src.charAt(i) != '\n') {
+                    i++;
+                }
+            } else if (c == '/' && i + 1 < n && src.charAt(i + 1) == '*') {
+                i += 2;
+                while (i + 1 < n && !(src.charAt(i) == '*' && src.charAt(i + 1) == '/')) {
+                    i++;
+                }
+                i += 2;
+            } else {
+                sb.append(c);
+                i++;
+            }
+        }
+        return sb.toString();
     }
 
     private boolean handleEvent(SnippetEvent ste) {

--- a/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
+++ b/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
@@ -384,10 +384,7 @@ public class JetShellTool {
 
     private void resetState(List<String> loadList) {
         closeState();
-        pendingSealedHeader = null;
-        pendingSealedName = null;
-        pendingSubtypeSources.clear();
-        pendingSubtypeNames.clear();
+        clearPendingSealed();
         replayableHistoryPrevious = replayableHistory;
         replayableHistory = new ArrayList<>();
 
@@ -476,9 +473,11 @@ public class JetShellTool {
                 pendingSubtypeNames.add(subtypeName);
                 return false;
             }
-            // The contiguous hierarchy ended; finalise it, then route this snippet
-            // afresh (it may itself open a new sealed hierarchy).
-            boolean failed = flushPendingSealed();
+            // The contiguous hierarchy ended; finalise this one block, then route the
+            // snippet afresh -- it may open a new (possibly nested) sealed hierarchy,
+            // which subsequent snippets will feed. Single-level flush here so a nested
+            // sealed subtype's own subtypes (still incoming) are not lost.
+            boolean failed = flushOneSealedBlock();
             return routeCompleteSource(source) || failed;
         }
         String sealedName = sealedTypeNameWithoutPermits(source);
@@ -490,34 +489,61 @@ public class JetShellTool {
         return processCompleteSource(source);
     }
 
-    // Evaluates a deferred sealed declaration with a synthesised permits clause,
-    // followed by its collected subtypes. No-op when nothing is pending.
+    // Fully drains any deferred sealed hierarchy, including nested blocks. Called
+    // at input boundaries (end of input, state-observing commands, /open, /reload).
     private boolean flushPendingSealed() {
+        boolean failed = false;
+        while (pendingSealedName != null) {
+            failed |= flushOneSealedBlock();
+        }
+        return failed;
+    }
+
+    // Evaluates a single deferred sealed declaration with a synthesised permits
+    // clause, followed by its collected subtypes. Subtypes are re-routed so a nested
+    // sealed subtype gets its own permits synthesised too. No-op when nothing pends.
+    private boolean flushOneSealedBlock() {
         if (pendingSealedName == null) {
             return false;
         }
         String header = pendingSealedHeader;
         List<String> subtypeSources = new ArrayList<>(pendingSubtypeSources);
         List<String> subtypeNames = new ArrayList<>(pendingSubtypeNames);
+        clearPendingSealed();
+
+        if (state == null) {
+            // The engine was closed; nothing can be evaluated.
+            return false;
+        }
+        try {
+            if (subtypeNames.isEmpty()) {
+                // No subtypes were found; evaluate the original as-is so JShell reports
+                // the genuine error, matching plain jshell behaviour.
+                return processCompleteSource(header);
+            }
+            // Evaluate the sealed type with its synthesised permits clause. This is the
+            // form JShell records as the snippet source, so /list, /save and /reload
+            // all show the same self-contained, re-runnable declaration.
+            String sealedWithPermits = injectPermits(header, subtypeNames);
+            boolean failed = processCompleteSource(sealedWithPermits);
+            for (String subtypeSource : subtypeSources) {
+                failed |= routeCompleteSource(subtypeSource);
+            }
+            return failed;
+        } catch (IllegalStateException ex) {
+            // The engine died mid-flush; abandon any deferred state so the drain loop
+            // in flushPendingSealed terminates.
+            live = false;
+            clearPendingSealed();
+            return false;
+        }
+    }
+
+    private void clearPendingSealed() {
         pendingSealedHeader = null;
         pendingSealedName = null;
         pendingSubtypeSources.clear();
         pendingSubtypeNames.clear();
-
-        if (subtypeNames.isEmpty()) {
-            // No subtypes were found; evaluate the original as-is so JShell reports
-            // the genuine error, matching plain jshell behaviour.
-            return processCompleteSource(header);
-        }
-        // Evaluate the sealed type with its synthesised permits clause. This is the
-        // form JShell records as the snippet source, so /list, /save and /reload all
-        // show the same self-contained, re-runnable declaration.
-        String sealedWithPermits = injectPermits(header, subtypeNames);
-        boolean failed = processCompleteSource(sealedWithPermits);
-        for (String subtypeSource : subtypeSources) {
-            failed |= processCompleteSource(subtypeSource);
-        }
-        return failed;
     }
 
     private boolean processCompleteSource(String source) {
@@ -540,9 +566,15 @@ public class JetShellTool {
 
     // --- Sealed-type deferral helpers (Issue #17) ---
 
-    private static final java.util.regex.Pattern TYPE_NAME =
-            java.util.regex.Pattern.compile("\\b(?:class|interface|record|enum)\\s+([A-Za-z_$][\\w$]*)");
-    private static final java.util.regex.Pattern SEALED_KW = java.util.regex.Pattern.compile("\\bsealed\\b");
+    // Anchored type-declaration matcher: leading annotations/modifiers, then the
+    // kind keyword (group 1) and the declared name (group 2). Anchoring to the
+    // start avoids matching keywords that appear inside string literals or comments.
+    private static final java.util.regex.Pattern TYPE_DECL = java.util.regex.Pattern.compile(
+            "^\\s*(?:@[\\w.]+(?:\\s*\\([^)]*\\))?\\s+"
+            + "|(?:public|protected|private|abstract|static|final|strictfp|sealed|non-sealed)\\s+)*"
+            + "(class|interface|record|enum)\\s+([A-Za-z_$][\\w$]*)");
+    // `sealed` as a modifier -- the negative lookbehind excludes the `non-sealed` keyword.
+    private static final java.util.regex.Pattern SEALED_MOD = java.util.regex.Pattern.compile("(?<!-)\\bsealed\\b");
     private static final java.util.regex.Pattern PERMITS_KW = java.util.regex.Pattern.compile("\\bpermits\\b");
     private static final java.util.regex.Pattern SUPERTYPE_KW =
             java.util.regex.Pattern.compile("\\b(?:extends|implements)\\b");
@@ -556,23 +588,56 @@ public class JetShellTool {
     // with no explicit `permits` clause; otherwise null.
     private static String sealedTypeNameWithoutPermits(String source) {
         String header = declHeader(source);
-        if (!SEALED_KW.matcher(header).find() || PERMITS_KW.matcher(header).find()) {
+        java.util.regex.Matcher decl = TYPE_DECL.matcher(header);
+        if (!decl.find()) {
             return null;
         }
-        java.util.regex.Matcher m = TYPE_NAME.matcher(header);
-        return m.find() ? m.group(1) : null;
+        String kind = decl.group(1);
+        if (!kind.equals("class") && !kind.equals("interface")) {
+            return null;
+        }
+        String modifiers = header.substring(0, decl.start(1));
+        if (!SEALED_MOD.matcher(modifiers).find() || PERMITS_KW.matcher(header).find()) {
+            return null;
+        }
+        return decl.group(2);
     }
 
     // Returns the declared type name if the snippet extends/implements `superName`
-    // (so it belongs in that sealed type's permits clause); otherwise null.
+    // as a direct supertype (so it belongs in that sealed type's permits clause);
+    // otherwise null. Generic type arguments are ignored, so a type that merely
+    // mentions the sealed type inside e.g. Iterable<Shape> is not treated as a subtype.
     private static String subtypeNameIfExtends(String source, String superName) {
         String header = declHeader(source);
-        java.util.regex.Matcher kw = SUPERTYPE_KW.matcher(header);
-        if (!kw.find() || !containsWord(header.substring(kw.start()), superName)) {
+        java.util.regex.Matcher decl = TYPE_DECL.matcher(header);
+        if (!decl.find()) {
             return null;
         }
-        java.util.regex.Matcher m = TYPE_NAME.matcher(header);
-        return m.find() ? m.group(1) : null;
+        java.util.regex.Matcher kw = SUPERTYPE_KW.matcher(header.substring(decl.end()));
+        if (!kw.find()) {
+            return null;
+        }
+        String supertypes = stripGenerics(header.substring(decl.end()).substring(kw.start()));
+        return containsWord(supertypes, superName) ? decl.group(2) : null;
+    }
+
+    // Removes the contents of balanced angle-bracket groups (generic arguments).
+    private static String stripGenerics(String text) {
+        StringBuilder sb = new StringBuilder(text.length());
+        int depth = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '<') {
+                depth++;
+            } else if (c == '>') {
+                if (depth > 0) {
+                    depth--;
+                }
+            } else if (depth == 0) {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     // Inserts `permits A, B, ...` immediately before the type body.
@@ -789,10 +854,17 @@ public class JetShellTool {
 
     // --- Command processing ---
 
+    // Commands that neither read nor replay snippet state. For these we leave a
+    // deferred sealed-type hierarchy pending so the user can keep declaring its
+    // subtypes; every other command finalises the hierarchy first (it may observe
+    // the resulting snippets). See Issue #17.
+    private static final Set<String> NON_STATE_COMMANDS =
+            Set.of("/help", "/classpath", "/resolve", "/deps", "/doc", "/source");
+
     private void processCommand(String cmd) {
-        // A command boundary finalises any deferred sealed-type hierarchy.
-        flushPendingSealed();
         if (cmd.startsWith("/-")) {
+            // Re-running a history entry depends on the current snippet state.
+            flushPendingSealed();
             try {
                 cmdUseHistoryEntry(Integer.parseInt(cmd.substring(1)));
                 return;
@@ -820,6 +892,9 @@ public class JetShellTool {
                         Arrays.stream(matches).map(c -> c.command).collect(Collectors.joining(", ")));
                 return;
             }
+        }
+        if (!NON_STATE_COMMANDS.contains(command.command)) {
+            flushPendingSealed();
         }
         boolean handled = command.run.handle(arg);
         if (handled && command.kind == CommandKind.REPLAY) {

--- a/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
+++ b/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
@@ -473,7 +473,7 @@ public class JetShellTool {
                 pendingSubtypeNames.add(subtypeName);
                 return false;
             }
-            if (isBlankOrCommentOnly(source) || isImport(source)) {
+            if (isTransparentToPendingHierarchy(source)) {
                 // A comment, blank or import snippet between the sealed type and its
                 // subtypes must not finalise the hierarchy; evaluate it and keep going.
                 return processCompleteSource(source);
@@ -665,28 +665,42 @@ public class JetShellTool {
         return beforeBody + " permits " + String.join(", ", subtypeNames) + " " + body;
     }
 
-    // True if `word` appears in `text` as an unqualified type reference -- a whole
-    // word not preceded by a dot, so a qualified name like java.rmi.Remote does not
-    // count as a reference to a local `Remote`.
+    // True if `word` appears in `text` as a whole, unqualified type reference: not
+    // adjoined to an identifier character or a dot on either side. This excludes both
+    // a qualified name whose tail is `word` (java.rmi.Remote) and a nested type whose
+    // qualifier is `word` (Shape.Marker), neither of which refers to a local `word`.
     private static boolean mentionsUnqualified(String text, String word) {
-        return java.util.regex.Pattern.compile("(?<![.\\w$])" + java.util.regex.Pattern.quote(word) + "\\b")
-                .matcher(text).find();
+        int from = 0;
+        while (true) {
+            int idx = text.indexOf(word, from);
+            if (idx < 0) {
+                return false;
+            }
+            boolean boundedBefore = idx == 0 || !isReferenceChar(text.charAt(idx - 1));
+            int after = idx + word.length();
+            boolean boundedAfter = after == text.length() || !isReferenceChar(text.charAt(after));
+            if (boundedBefore && boundedAfter) {
+                return true;
+            }
+            from = idx + 1;
+        }
     }
 
-    // True if the snippet contains nothing but comments and whitespace, so it must
-    // be transparent to a pending sealed hierarchy rather than finalising it.
-    private static boolean isBlankOrCommentOnly(String source) {
-        return stripComments(source).isBlank();
+    private static boolean isReferenceChar(char c) {
+        return c == '.' || Character.isJavaIdentifierPart(c);
     }
 
     private static final java.util.regex.Pattern IMPORT_STMT =
             java.util.regex.Pattern.compile("^\\s*import\\b");
 
-    // True if the snippet is an import statement. Imports are order-independent and,
-    // unlike in a single .java file, JShell allows them anywhere, so an interleaved
-    // import must stay transparent to a pending sealed hierarchy.
-    private static boolean isImport(String source) {
-        return IMPORT_STMT.matcher(stripComments(source)).find();
+    // True if the snippet is transparent to a pending sealed hierarchy: nothing but
+    // comments/whitespace, or an import. Imports are order-independent and, unlike in
+    // a single .java file, JShell allows them anywhere, so an interleaved import (or a
+    // stray comment between declarations) must not finalise the hierarchy. Strips
+    // comments once and reuses the result for both checks.
+    private static boolean isTransparentToPendingHierarchy(String source) {
+        String stripped = stripComments(source);
+        return stripped.isBlank() || IMPORT_STMT.matcher(stripped).find();
     }
 
     // Removes line and block comments, while preserving string, char and text-block
@@ -697,49 +711,19 @@ public class JetShellTool {
         int i = 0;
         int n = src.length();
         while (i < n) {
-            char c = src.charAt(i);
-            if (c == '/' && i + 1 < n && src.charAt(i + 1) == '/') {
-                i += 2;
-                while (i < n && src.charAt(i) != '\n') {
-                    i++;
-                }
-            } else if (c == '/' && i + 1 < n && src.charAt(i + 1) == '*') {
-                i += 2;
-                while (i + 1 < n && !(src.charAt(i) == '*' && src.charAt(i + 1) == '/')) {
-                    i++;
-                }
-                i += 2;
-            } else if (isTextBlockStart(src, i)) {
-                sb.append("\"\"\"");
-                i += 3;
-                while (i < n && !isTextBlockStart(src, i)) {
-                    sb.append(src.charAt(i));
-                    i++;
-                }
-                if (i < n) {
-                    sb.append("\"\"\"");
-                    i += 3;
-                }
-            } else if (c == '"' || c == '\'') {
-                sb.append(c);
-                i++;
-                while (i < n && src.charAt(i) != c) {
-                    sb.append(src.charAt(i));
-                    if (src.charAt(i) == '\\' && i + 1 < n) {
-                        sb.append(src.charAt(i + 1));
-                        i += 2;
-                    } else {
-                        i++;
-                    }
-                }
-                if (i < n) {
-                    sb.append(c);
-                    i++;
-                }
-            } else {
-                sb.append(c);
-                i++;
+            int afterComment = commentEnd(src, i);
+            if (afterComment != i) {
+                i = afterComment;
+                continue;
             }
+            int afterLiteral = literalEnd(src, i);
+            if (afterLiteral != i) {
+                sb.append(src, i, afterLiteral);
+                i = afterLiteral;
+                continue;
+            }
+            sb.append(src.charAt(i));
+            i++;
         }
         return sb.toString();
     }
@@ -757,51 +741,16 @@ public class JetShellTool {
                 return i;
             } else if (c == '(') {
                 i = skipParens(src, i);
-            } else if (c == '/' && i + 1 < n && src.charAt(i + 1) == '/') {
-                i += 2;
-                while (i < n && src.charAt(i) != '\n') {
-                    i++;
-                }
-            } else if (c == '/' && i + 1 < n && src.charAt(i + 1) == '*') {
-                i += 2;
-                while (i + 1 < n && !(src.charAt(i) == '*' && src.charAt(i + 1) == '/')) {
-                    i++;
-                }
-                i += 2;
-            } else if (isTextBlockStart(src, i)) {
-                i += 3;
-                while (i < n && !isTextBlockStart(src, i)) {
-                    i++;
-                }
-                i += 3;
-            } else if (c == '"' || c == '\'') {
-                i = skipQuoted(src, i);
-            } else {
-                i++;
+                continue;
             }
+            int next = skipNoise(src, i);
+            i = (next != i) ? next : i + 1;
         }
         return -1;
     }
 
-    private static boolean isTextBlockStart(String src, int i) {
-        return i + 2 < src.length()
-                && src.charAt(i) == '"' && src.charAt(i + 1) == '"' && src.charAt(i + 2) == '"';
-    }
-
-    // Given the index of an opening quote, returns the index just past the closing
-    // quote (escapes respected). Used to skip string and char literals.
-    private static int skipQuoted(String src, int open) {
-        char q = src.charAt(open);
-        int i = open + 1;
-        int n = src.length();
-        while (i < n && src.charAt(i) != q) {
-            i += (src.charAt(i) == '\\' && i + 1 < n) ? 2 : 1;
-        }
-        return i < n ? i + 1 : i;
-    }
-
     // Given the index of an opening '(', returns the index just past the matching
-    // ')', tracking nested parens and skipping string/char literals (so an arg such
+    // ')', tracking nested parens and skipping comments and literals (so an arg such
     // as ")" or {"a"} is consumed correctly). Returns the length if unbalanced.
     private static int skipParens(String src, int open) {
         int depth = 0;
@@ -809,9 +758,7 @@ public class JetShellTool {
         int n = src.length();
         while (i < n) {
             char c = src.charAt(i);
-            if (c == '"' || c == '\'') {
-                i = skipQuoted(src, i);
-            } else if (c == '(') {
+            if (c == '(') {
                 depth++;
                 i++;
             } else if (c == ')') {
@@ -821,10 +768,69 @@ public class JetShellTool {
                     return i;
                 }
             } else {
-                i++;
+                int next = skipNoise(src, i);
+                i = (next != i) ? next : i + 1;
             }
         }
         return n;
+    }
+
+    // If a comment or a string/char/text-block literal starts at i, returns the index
+    // just past it; otherwise returns i unchanged.
+    private static int skipNoise(String src, int i) {
+        int afterComment = commentEnd(src, i);
+        if (afterComment != i) {
+            return afterComment;
+        }
+        return literalEnd(src, i);
+    }
+
+    // If a line or block comment starts at i, returns the index just past it;
+    // otherwise returns i.
+    private static int commentEnd(String src, int i) {
+        int n = src.length();
+        if (i + 1 < n && src.charAt(i) == '/' && src.charAt(i + 1) == '/') {
+            i += 2;
+            while (i < n && src.charAt(i) != '\n') {
+                i++;
+            }
+            return i;
+        }
+        if (i + 1 < n && src.charAt(i) == '/' && src.charAt(i + 1) == '*') {
+            i += 2;
+            while (i + 1 < n && !(src.charAt(i) == '*' && src.charAt(i + 1) == '/')) {
+                i++;
+            }
+            return Math.min(i + 2, n);
+        }
+        return i;
+    }
+
+    // If a string, char or text-block literal starts at i, returns the index just
+    // past it (escapes respected); otherwise returns i.
+    private static int literalEnd(String src, int i) {
+        int n = src.length();
+        if (isTextBlockStart(src, i)) {
+            i += 3;
+            while (i < n && !isTextBlockStart(src, i)) {
+                i++;
+            }
+            return Math.min(i + 3, n);
+        }
+        char c = src.charAt(i);
+        if (c == '"' || c == '\'') {
+            i++;
+            while (i < n && src.charAt(i) != c) {
+                i += (src.charAt(i) == '\\' && i + 1 < n) ? 2 : 1;
+            }
+            return i < n ? i + 1 : i;
+        }
+        return i;
+    }
+
+    private static boolean isTextBlockStart(String src, int i) {
+        return i + 2 < src.length()
+                && src.charAt(i) == '"' && src.charAt(i + 1) == '"' && src.charAt(i + 2) == '"';
     }
 
     // Removes annotations (@Name and @Name(...)) from a declaration header so the

--- a/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
+++ b/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
@@ -48,6 +48,16 @@ public class JetShellTool {
     private boolean suppressOutput = false;
     private boolean hadFailure = false;
 
+    // A sealed interface/class whose permitted subtypes are declared on later lines
+    // cannot compile as its own JShell compilation unit (no permits, no same-unit
+    // subtypes). We defer such a declaration, collect the contiguous subtype
+    // declarations that follow, then synthesise an explicit permits clause so the
+    // whole hierarchy compiles -- the same way it would as a single .java file.
+    private String pendingSealedHeader;
+    private String pendingSealedName;
+    private final List<String> pendingSubtypeSources = new ArrayList<>();
+    private final List<String> pendingSubtypeNames = new ArrayList<>();
+
     public boolean testPrompt = false;
 
     boolean hadFailure() {
@@ -316,6 +326,7 @@ public class JetShellTool {
                 }
                 incomplete = processInput(raw, incomplete);
             }
+            flushPendingSealed();
         } catch (Exception ex) {
             hard("Unexpected exception: %s", ex);
             hadFailure = true;
@@ -336,6 +347,7 @@ public class JetShellTool {
             }
             incomplete = processInput(raw, incomplete);
         }
+        flushPendingSealed();
     }
 
     private String processInput(String raw, String incomplete) {
@@ -372,6 +384,10 @@ public class JetShellTool {
 
     private void resetState(List<String> loadList) {
         closeState();
+        pendingSealedHeader = null;
+        pendingSealedName = null;
+        pendingSubtypeSources.clear();
+        pendingSubtypeNames.clear();
         replayableHistoryPrevious = replayableHistory;
         replayableHistory = new ArrayList<>();
 
@@ -401,6 +417,7 @@ public class JetShellTool {
         if (!start.isBlank()) {
             suppressOutput = true;
             processSource(start);
+            flushPendingSealed();
             suppressOutput = false;
             // Record snippet IDs that belong to startup so /list start can filter them
             startupSnippetIds = state.snippets()
@@ -441,12 +458,66 @@ public class JetShellTool {
             if (!an.completeness().isComplete()) {
                 return an.remaining();
             }
-            boolean failed = processCompleteSource(an.source());
+            boolean failed = routeCompleteSource(an.source());
             if (failed || an.remaining().isEmpty()) {
                 return "";
             }
             srcInput = an.remaining();
         }
+    }
+
+    // Routes a complete snippet, deferring a sealed-type hierarchy so an explicit
+    // permits clause can be synthesised once its subtypes are known (see Issue #17).
+    private boolean routeCompleteSource(String source) {
+        if (pendingSealedName != null) {
+            String subtypeName = subtypeNameIfExtends(source, pendingSealedName);
+            if (subtypeName != null) {
+                pendingSubtypeSources.add(source);
+                pendingSubtypeNames.add(subtypeName);
+                return false;
+            }
+            // The contiguous hierarchy ended; finalise it, then route this snippet
+            // afresh (it may itself open a new sealed hierarchy).
+            boolean failed = flushPendingSealed();
+            return routeCompleteSource(source) || failed;
+        }
+        String sealedName = sealedTypeNameWithoutPermits(source);
+        if (sealedName != null) {
+            pendingSealedHeader = source;
+            pendingSealedName = sealedName;
+            return false;
+        }
+        return processCompleteSource(source);
+    }
+
+    // Evaluates a deferred sealed declaration with a synthesised permits clause,
+    // followed by its collected subtypes. No-op when nothing is pending.
+    private boolean flushPendingSealed() {
+        if (pendingSealedName == null) {
+            return false;
+        }
+        String header = pendingSealedHeader;
+        List<String> subtypeSources = new ArrayList<>(pendingSubtypeSources);
+        List<String> subtypeNames = new ArrayList<>(pendingSubtypeNames);
+        pendingSealedHeader = null;
+        pendingSealedName = null;
+        pendingSubtypeSources.clear();
+        pendingSubtypeNames.clear();
+
+        if (subtypeNames.isEmpty()) {
+            // No subtypes were found; evaluate the original as-is so JShell reports
+            // the genuine error, matching plain jshell behaviour.
+            return processCompleteSource(header);
+        }
+        // Evaluate the sealed type with its synthesised permits clause. This is the
+        // form JShell records as the snippet source, so /list, /save and /reload all
+        // show the same self-contained, re-runnable declaration.
+        String sealedWithPermits = injectPermits(header, subtypeNames);
+        boolean failed = processCompleteSource(sealedWithPermits);
+        for (String subtypeSource : subtypeSources) {
+            failed |= processCompleteSource(subtypeSource);
+        }
+        return failed;
     }
 
     private boolean processCompleteSource(String source) {
@@ -465,6 +536,59 @@ public class JetShellTool {
             replayableHistory.add(source);
         }
         return failed;
+    }
+
+    // --- Sealed-type deferral helpers (Issue #17) ---
+
+    private static final java.util.regex.Pattern TYPE_NAME =
+            java.util.regex.Pattern.compile("\\b(?:class|interface|record|enum)\\s+([A-Za-z_$][\\w$]*)");
+    private static final java.util.regex.Pattern SEALED_KW = java.util.regex.Pattern.compile("\\bsealed\\b");
+    private static final java.util.regex.Pattern PERMITS_KW = java.util.regex.Pattern.compile("\\bpermits\\b");
+    private static final java.util.regex.Pattern SUPERTYPE_KW =
+            java.util.regex.Pattern.compile("\\b(?:extends|implements)\\b");
+
+    private static String declHeader(String source) {
+        int brace = source.indexOf('{');
+        return brace >= 0 ? source.substring(0, brace) : source;
+    }
+
+    // Returns the declared type name if the snippet is a `sealed` interface/class
+    // with no explicit `permits` clause; otherwise null.
+    private static String sealedTypeNameWithoutPermits(String source) {
+        String header = declHeader(source);
+        if (!SEALED_KW.matcher(header).find() || PERMITS_KW.matcher(header).find()) {
+            return null;
+        }
+        java.util.regex.Matcher m = TYPE_NAME.matcher(header);
+        return m.find() ? m.group(1) : null;
+    }
+
+    // Returns the declared type name if the snippet extends/implements `superName`
+    // (so it belongs in that sealed type's permits clause); otherwise null.
+    private static String subtypeNameIfExtends(String source, String superName) {
+        String header = declHeader(source);
+        java.util.regex.Matcher kw = SUPERTYPE_KW.matcher(header);
+        if (!kw.find() || !containsWord(header.substring(kw.start()), superName)) {
+            return null;
+        }
+        java.util.regex.Matcher m = TYPE_NAME.matcher(header);
+        return m.find() ? m.group(1) : null;
+    }
+
+    // Inserts `permits A, B, ...` immediately before the type body.
+    private static String injectPermits(String header, List<String> subtypeNames) {
+        int brace = header.indexOf('{');
+        if (brace < 0) {
+            return header;
+        }
+        String beforeBody = header.substring(0, brace).stripTrailing();
+        String body = header.substring(brace);
+        return beforeBody + " permits " + String.join(", ", subtypeNames) + " " + body;
+    }
+
+    private static boolean containsWord(String text, String word) {
+        return java.util.regex.Pattern.compile("\\b" + java.util.regex.Pattern.quote(word) + "\\b")
+                .matcher(text).find();
     }
 
     private boolean handleEvent(SnippetEvent ste) {
@@ -666,6 +790,8 @@ public class JetShellTool {
     // --- Command processing ---
 
     private void processCommand(String cmd) {
+        // A command boundary finalises any deferred sealed-type hierarchy.
+        flushPendingSealed();
         if (cmd.startsWith("/-")) {
             try {
                 cmdUseHistoryEntry(Integer.parseInt(cmd.substring(1)));
@@ -969,6 +1095,7 @@ public class JetShellTool {
         try {
             String content = Files.readString(toPathResolvingUserHome(filename));
             processSource(content);
+            flushPendingSealed();
         } catch (IOException e) {
             error("File '%s' not found: %s", filename, e.getMessage());
         }
@@ -1025,6 +1152,7 @@ public class JetShellTool {
             }
             processSource(source);
         }
+        flushPendingSealed();
     }
 
     private void cmdClasspath(String arg) {

--- a/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
+++ b/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
@@ -207,4 +207,30 @@ public class SealedTypeBatchTest {
         assertTrue(output.contains("Expression value is: 8.0"),
                 "An interleaved import must not break the hierarchy. Output:\n" + output);
     }
+
+    // Copilot review: an annotation whose argument string contains ')' must not
+    // defeat declaration detection.
+    public void annotationArgumentWithParenIsHandled() throws Exception {
+        String output = run(
+                "@SuppressWarnings(\")x\") sealed interface Shape {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                "new Circle(2.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 2.0"),
+                "A ')' inside an annotation string must not break detection. Output:\n" + output);
+    }
+
+    // Copilot review: an annotation array argument contains braces that must not be
+    // mistaken for the type body.
+    public void annotationArrayArgumentIsHandled() throws Exception {
+        String output = run(
+                "@SuppressWarnings({\"a\", \"b\"}) sealed interface Shape {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                "new Circle(3.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 3.0"),
+                "Braces in an annotation array must not be read as the type body. Output:\n" + output);
+    }
 }

--- a/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
+++ b/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
@@ -7,6 +7,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -113,5 +115,42 @@ public class SealedTypeBatchTest {
                 "/exit\n");
         assertTrue(output.contains("Expression value is: 4.0"),
                 "non-sealed subtype and string literal must not break the hierarchy. Output:\n" + output);
+    }
+
+    // Copilot review #1: a comment or blank line between the sealed type and its
+    // subtypes (as seen when a whole file is processed via /open) must not finalise
+    // the hierarchy prematurely.
+    public void commentsBetweenSealedTypeAndSubtypesDoNotBreakIt() throws Exception {
+        Path file = Files.createTempFile("hier", ".jsh");
+        Files.writeString(file,
+                "sealed interface Shape {}\n" +
+                "// the circle case\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "\n" +
+                "/* the rectangle case */\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                "new Circle(6.0).radius()\n");
+        try {
+            String output = run("/open " + file + "\n/exit\n");
+            assertTrue(output.contains("Expression value is: 6.0"),
+                    "Comments/blank lines must be transparent to the hierarchy. Output:\n" + output);
+        } finally {
+            Files.deleteIfExists(file);
+        }
+    }
+
+    // Copilot review #2: a supertype referenced by a qualified name whose final
+    // segment equals the sealed type's simple name (e.g. java.rmi.Remote vs a local
+    // Remote) must NOT be treated as a permitted subtype.
+    public void qualifiedSupertypeSharingSimpleNameIsNotPermitted() throws Exception {
+        String output = run(
+                "sealed interface Remote {}\n" +
+                "record Node() implements Remote {}\n" +
+                // Gateway extends the JDK's java.rmi.Remote, a different type.
+                "interface Gateway extends java.rmi.Remote {}\n" +
+                "new Node()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: Node[]"),
+                "Gateway (java.rmi.Remote) must not join the local Remote's permits. Output:\n" + output);
     }
 }

--- a/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
+++ b/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
@@ -1,0 +1,72 @@
+package net.unit8.jetshell.tool;
+
+import net.unit8.jetshell.command.JetShellCommandRegister;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Issue #17: a {@code sealed interface}/{@code sealed class} whose permitted
+ * subtypes are declared on later lines must compile in (non-interactive) batch
+ * mode, the same way it would as a single {@code .java} source file.
+ */
+@Test
+public class SealedTypeBatchTest {
+
+    private static String run(String script) throws Exception {
+        ByteArrayInputStream in = new ByteArrayInputStream(script.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(out, true, StandardCharsets.UTF_8);
+        JetShellTool tool = JetShellTool.create(in, ps, ps);
+        new JetShellCommandRegister().register(tool);
+        tool.testPrompt = true;
+        int exitCode = tool.start(new String[0]);
+        ps.flush();
+        String output = out.toString(StandardCharsets.UTF_8);
+        assertEquals(exitCode, 0, "Script should succeed but exited " + exitCode + ". Output:\n" + output);
+        return output;
+    }
+
+    public void sealedInterfaceWithLaterSubtypesCompilesAndSubtypesAreUsable() throws Exception {
+        String output = run(
+                "sealed interface Shape {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                // A bare expression yields JShell's "Expression value is:" feedback,
+                // proving Circle is an independently usable snippet.
+                "new Circle(2.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 2.0"),
+                "Circle should be an independently usable snippet. Output:\n" + output);
+    }
+
+    public void sealednessIsPreservedSoExhaustiveSwitchNeedsNoDefault() throws Exception {
+        String output = run(
+                "sealed interface Shape {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                // A switch with no default compiles only when Shape is genuinely sealed
+                // to exactly {Circle, Rect}.
+                "String k = switch ((Shape) new Circle(1.0)) { case Circle c -> \"C\"; case Rect r -> \"R\"; };\n" +
+                "/exit\n");
+        assertTrue(output.contains("with initial value \"C\""),
+                "Exhaustive switch over the sealed type should compile and run. Output:\n" + output);
+    }
+
+    public void sealedClassWithLaterSubclassesCompiles() throws Exception {
+        String output = run(
+                "sealed abstract class Expr {}\n" +
+                "final class Lit extends Expr { int v; Lit(int v){ this.v = v; } }\n" +
+                "final class Neg extends Expr { Expr e; Neg(Expr e){ this.e = e; } }\n" +
+                "new Lit(7).v\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 7"),
+                "sealed class subclasses should be usable. Output:\n" + output);
+    }
+}

--- a/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
+++ b/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
@@ -233,4 +233,18 @@ public class SealedTypeBatchTest {
         assertTrue(output.contains("Expression value is: 3.0"),
                 "Braces in an annotation array must not be read as the type body. Output:\n" + output);
     }
+
+    // Review: a type implementing a NESTED type of the sealed type (Shape.Marker)
+    // must not be treated as a subtype of the outer sealed type.
+    public void subtypeOfNestedTypeIsNotPermittedOnOuter() throws Exception {
+        String output = run(
+                "sealed interface Shape { interface Marker {} }\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                // Tag implements Shape.Marker, NOT Shape.
+                "class Tag implements Shape.Marker {}\n" +
+                "new Circle(2.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 2.0"),
+                "Tag (Shape.Marker) must not join the outer Shape's permits. Output:\n" + output);
+    }
 }

--- a/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
+++ b/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
@@ -69,4 +69,49 @@ public class SealedTypeBatchTest {
         assertTrue(output.contains("Expression value is: 7"),
                 "sealed class subclasses should be usable. Output:\n" + output);
     }
+
+    // Finding #1: a following type that merely mentions the sealed type inside a
+    // generic supertype argument must NOT be pulled into the permits clause.
+    public void unrelatedTypeMentioningSealedInGenericsIsNotPermitted() throws Exception {
+        String output = run(
+                "sealed interface Shape {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                // Iterable<Shape>: Shape appears only as a type argument, not as a supertype.
+                "class ShapeBag implements Iterable<Shape> {\n" +
+                "  public java.util.Iterator<Shape> iterator() { return java.util.List.<Shape>of().iterator(); }\n" +
+                "}\n" +
+                "new Circle(3.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 3.0"),
+                "The sealed hierarchy must compile; ShapeBag must not join its permits. Output:\n" + output);
+    }
+
+    // Finding #2: a nested sealed type (itself a subtype) must also be deferred and
+    // given a synthesised permits clause, not evaluated as-is.
+    public void nestedSealedHierarchyCompiles() throws Exception {
+        String output = run(
+                "sealed interface Shape {}\n" +
+                "sealed interface Poly extends Shape {}\n" +
+                "record Tri() implements Poly {}\n" +
+                "record Quad() implements Poly {}\n" +
+                "new Tri()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: Tri[]"),
+                "Nested sealed hierarchy should compile end to end. Output:\n" + output);
+    }
+
+    // Finding #4: a `non-sealed` subtype must not be misread as a sealed declaration,
+    // and a string literal containing declaration-like text must not derail parsing.
+    public void nonSealedSubtypeAndStringLiteralAreHandled() throws Exception {
+        String output = run(
+                "String note = \"sealed interface Ghost {}\";\n" +
+                "sealed interface Shape {}\n" +
+                "non-sealed interface Openable extends Shape {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "new Circle(4.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 4.0"),
+                "non-sealed subtype and string literal must not break the hierarchy. Output:\n" + output);
+    }
 }

--- a/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
+++ b/src/test/java/net/unit8/jetshell/tool/SealedTypeBatchTest.java
@@ -153,4 +153,58 @@ public class SealedTypeBatchTest {
         assertTrue(output.contains("Expression value is: Node[]"),
                 "Gateway (java.rmi.Remote) must not join the local Remote's permits. Output:\n" + output);
     }
+
+    // Review #1: a `extends` inside a type-parameter bound must not be read as a
+    // supertype, so a generic type bounded by the sealed type is not a subtype.
+    public void typeParameterBoundIsNotASupertype() throws Exception {
+        String output = run(
+                "sealed interface Shape {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                // Registry is bounded by Shape but does NOT extend/implement it.
+                "class Registry<T extends Shape> { T held; }\n" +
+                "new Circle(3.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 3.0"),
+                "A type-parameter bound must not make Registry a permitted subtype. Output:\n" + output);
+    }
+
+    // Review #2: a `//` or `/*` inside a string literal in the declaration header
+    // must not be treated as a comment and truncate detection.
+    public void commentMarkerInsideStringLiteralDoesNotBreakDetection() throws Exception {
+        String output = run(
+                "@SuppressWarnings(\"a//b\") sealed interface Shape {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                "new Circle(5.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 5.0"),
+                "A string literal containing // must not break sealed detection. Output:\n" + output);
+    }
+
+    // Review #3: a brace inside a comment in the sealed header must not be mistaken
+    // for the type body when the permits clause is injected.
+    public void braceInsideCommentInSealedHeaderIsHandled() throws Exception {
+        String output = run(
+                "sealed interface Shape /* body starts at { below */ {}\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                "new Circle(7.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 7.0"),
+                "A brace inside a comment must not misplace the permits clause. Output:\n" + output);
+    }
+
+    // Review #4: an import statement between the sealed type and its subtypes must
+    // be transparent to the hierarchy, not finalise it prematurely.
+    public void importBetweenSealedTypeAndSubtypesIsTransparent() throws Exception {
+        String output = run(
+                "sealed interface Shape {}\n" +
+                "import java.util.Optional;\n" +
+                "record Circle(double radius) implements Shape {}\n" +
+                "record Rect(double width, double height) implements Shape {}\n" +
+                "new Circle(8.0).radius()\n" +
+                "/exit\n");
+        assertTrue(output.contains("Expression value is: 8.0"),
+                "An interleaved import must not break the hierarchy. Output:\n" + output);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #17. In batch mode (and interactive mode alike), a `sealed interface`/`sealed class` whose permitted subtypes are declared on **later** lines failed to compile. Each statement is evaluated as its own JShell compilation unit, so the sealed type stood alone with no `permits` clause and no same-unit subtypes — javac rejected it with *"a sealed class must have subclasses"*, and every referencing snippet cascaded to failure. Plain `jshell` shows the identical behaviour, so this brings jetshell to parity with a single `.java` source file.

## Root cause

`processSource` splits input via `analyzeCompletion` and evaluates each complete snippet immediately. `sealed interface Shape {}` is a complete snippet on its own, so it is `eval`'d before its subtypes are seen. A sealed type's permitted subtypes must live in the same compilation unit; a standalone one with **implicit** permits is a hard `REJECTED` error.

## Fix

Verified against the JShell API: with an **explicit** `permits` clause, JShell treats not-yet-declared subtypes as *recoverable forward references* and resolves the whole hierarchy to `VALID` once the last subtype appears — subtypes stay independently usable and sealed-ness is preserved.

So the tool now:

1. **Defers** a `sealed` type that has no explicit `permits` clause.
2. **Collects** the contiguous subtype declarations that follow (those that `extends`/`implements` it).
3. **Synthesises** `permits A, B, ...` and evaluates the hierarchy.

The deferred block is flushed at a command boundary, at end of input, and after `/open` and `/reload`.

- A sealed type that never gains subtypes still reports the genuine error (no silent swallowing).
- A type that already declares `permits` is left untouched.
- Sealed-ness is genuinely preserved: an exhaustive `switch` over the type compiles with **no** `default`.
- `/list`, `/save` and `/reload` all show the same self-contained, re-runnable form.

## Testing

- New `SealedTypeBatchTest` (3 cases): sealed interface + later records usable; sealed-ness preserved (exhaustive switch, no default); sealed abstract class + final subclasses.
- Full suite: 36/36 green.
- Verified end-to-end against the built `target/jetshell` with the exact reproduction from the issue, plus edge cases (explicit-permits untouched, lone sealed still errors, generic/`extends`-clause hierarchies, plain interface unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)