### PR TITLE
feat: add -plain / -quiet flags for machine-readable batch output (#12)

### DIFF
--- a/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
+++ b/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
@@ -48,11 +48,29 @@ public class JetShellTool {
     private boolean suppressOutput = false;
     private boolean hadFailure = false;
 
-    // Batch output verbosity, selected by -plain / -quiet (see Issue #12).
-    //   NORMAL: informational and error lines carry the "|  " prefix (interactive-friendly).
-    //   PLAIN:  same streams, but no prefix (grep/diff-friendly).
-    //   QUIET:  informational output is suppressed; errors still go to stderr, unprefixed.
-    enum OutputMode { NORMAL, PLAIN, QUIET }
+    // Batch output verbosity, selected by -plain / -quiet (see Issue #12). Each mode
+    // carries its whole policy so it lives in one table (cf. CommandKind below):
+    //   prefix        -- prepended to every line ("|  " only interactively).
+    //   mutesInfo     -- hard() informational output is suppressed.
+    //   errorsToStderr-- problem() diagnostics go to stderr instead of stdout.
+    //   showsPrompt   -- the input prompt is emitted.
+    enum OutputMode {
+        NORMAL("|  ", false, false, true),
+        PLAIN("", false, false, false),
+        QUIET("", true, true, false);
+
+        final String prefix;
+        final boolean mutesInfo;
+        final boolean errorsToStderr;
+        final boolean showsPrompt;
+
+        OutputMode(String prefix, boolean mutesInfo, boolean errorsToStderr, boolean showsPrompt) {
+            this.prefix = prefix;
+            this.mutesInfo = mutesInfo;
+            this.errorsToStderr = errorsToStderr;
+            this.showsPrompt = showsPrompt;
+        }
+    }
     private OutputMode outputMode = OutputMode.NORMAL;
 
     // A sealed interface/class whose permitted subtypes are declared on later lines
@@ -127,31 +145,32 @@ public class JetShellTool {
 
     // --- Output helpers ---
 
-    // The "|  " prefix is only added in NORMAL mode; -plain / -quiet drop it.
-    private String outputPrefix() {
-        return outputMode == OutputMode.NORMAL ? "|  " : "";
+    private void emit(PrintStream stream, String format, Object... args) {
+        stream.printf(outputMode.prefix + format + "%n", args);
     }
 
     // Informational output (declarations, expression values, banners). Muted during
     // startup and entirely in QUIET mode.
     public void hard(String format, Object... args) {
-        if (suppressOutput || outputMode == OutputMode.QUIET) {
+        if (suppressOutput || outputMode.mutesInfo) {
             return;
         }
-        cmdout.printf(outputPrefix() + format + "%n", args);
+        emit(cmdout, format, args);
     }
 
     // Snippet compile/runtime error output. Stays on stdout in NORMAL/PLAIN (as it
     // always has), but is redirected to stderr in QUIET so it survives the silenced
-    // stdout. Not muted during startup, so a bad startup snippet is still reported.
+    // stdout. Muted during startup, like hard(), so start-up noise stays hidden.
     public void problem(String format, Object... args) {
-        PrintStream out = outputMode == OutputMode.QUIET ? cmderr : cmdout;
-        out.printf(outputPrefix() + format + "%n", args);
+        if (suppressOutput) {
+            return;
+        }
+        emit(outputMode.errorsToStderr ? cmderr : cmdout, format, args);
     }
 
     public void error(String format, Object... args) {
         // Errors are always shown, even during startup (suppressOutput only mutes normal output)
-        cmderr.printf(outputPrefix() + format + "%n", args);
+        emit(cmderr, format, args);
     }
 
     public void fluff(String format, Object... args) {
@@ -337,7 +356,7 @@ public class JetShellTool {
         try {
             while (live) {
                 // -plain / -quiet drop the prompt so batch output stays machine-clean.
-                String prompt = outputMode != OutputMode.NORMAL ? ""
+                String prompt = !outputMode.showsPrompt ? ""
                         : incomplete.isEmpty() ? "\n-> " : ">> ";
                 String raw;
                 try {
@@ -361,10 +380,9 @@ public class JetShellTool {
     private void runWithReader(BufferedReader reader) throws IOException {
         String incomplete = "";
         while (live) {
-            String prompt = incomplete.isEmpty() ? "\u0005" : "\u0006";
             // -plain / -quiet drop the prompt so batch output stays machine-clean.
-            if (outputMode == OutputMode.NORMAL) {
-                console.print(prompt);
+            if (outputMode.showsPrompt) {
+                console.print(incomplete.isEmpty() ? "\u0005" : "\u0006");
                 console.flush();
             }
 

--- a/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
+++ b/src/main/java/net/unit8/jetshell/tool/JetShellTool.java
@@ -48,6 +48,13 @@ public class JetShellTool {
     private boolean suppressOutput = false;
     private boolean hadFailure = false;
 
+    // Batch output verbosity, selected by -plain / -quiet (see Issue #12).
+    //   NORMAL: informational and error lines carry the "|  " prefix (interactive-friendly).
+    //   PLAIN:  same streams, but no prefix (grep/diff-friendly).
+    //   QUIET:  informational output is suppressed; errors still go to stderr, unprefixed.
+    enum OutputMode { NORMAL, PLAIN, QUIET }
+    private OutputMode outputMode = OutputMode.NORMAL;
+
     // A sealed interface/class whose permitted subtypes are declared on later lines
     // cannot compile as its own JShell compilation unit (no permits, no same-unit
     // subtypes). We defer such a declaration, collect the contiguous subtype
@@ -120,15 +127,31 @@ public class JetShellTool {
 
     // --- Output helpers ---
 
+    // The "|  " prefix is only added in NORMAL mode; -plain / -quiet drop it.
+    private String outputPrefix() {
+        return outputMode == OutputMode.NORMAL ? "|  " : "";
+    }
+
+    // Informational output (declarations, expression values, banners). Muted during
+    // startup and entirely in QUIET mode.
     public void hard(String format, Object... args) {
-        if (!suppressOutput) {
-            cmdout.printf("|  " + format + "%n", args);
+        if (suppressOutput || outputMode == OutputMode.QUIET) {
+            return;
         }
+        cmdout.printf(outputPrefix() + format + "%n", args);
+    }
+
+    // Snippet compile/runtime error output. Stays on stdout in NORMAL/PLAIN (as it
+    // always has), but is redirected to stderr in QUIET so it survives the silenced
+    // stdout. Not muted during startup, so a bad startup snippet is still reported.
+    public void problem(String format, Object... args) {
+        PrintStream out = outputMode == OutputMode.QUIET ? cmderr : cmdout;
+        out.printf(outputPrefix() + format + "%n", args);
     }
 
     public void error(String format, Object... args) {
         // Errors are always shown, even during startup (suppressOutput only mutes normal output)
-        cmderr.printf("|  " + format + "%n", args);
+        cmderr.printf(outputPrefix() + format + "%n", args);
     }
 
     public void fluff(String format, Object... args) {
@@ -302,7 +325,7 @@ public class JetShellTool {
                 runWithReader(reader);
             }
         } catch (IOException ex) {
-            hard("Unexpected exception: %s", ex);
+            problem("Unexpected exception: %s", ex);
             hadFailure = true;
         } finally {
             closeState();
@@ -313,7 +336,9 @@ public class JetShellTool {
         String incomplete = "";
         try {
             while (live) {
-                String prompt = incomplete.isEmpty() ? "\n-> " : ">> ";
+                // -plain / -quiet drop the prompt so batch output stays machine-clean.
+                String prompt = outputMode != OutputMode.NORMAL ? ""
+                        : incomplete.isEmpty() ? "\n-> " : ">> ";
                 String raw;
                 try {
                     raw = lineReader.readLine(prompt);
@@ -328,7 +353,7 @@ public class JetShellTool {
             }
             flushPendingSealed();
         } catch (Exception ex) {
-            hard("Unexpected exception: %s", ex);
+            problem("Unexpected exception: %s", ex);
             hadFailure = true;
         }
     }
@@ -337,8 +362,11 @@ public class JetShellTool {
         String incomplete = "";
         while (live) {
             String prompt = incomplete.isEmpty() ? "\u0005" : "\u0006";
-            console.print(prompt);
-            console.flush();
+            // -plain / -quiet drop the prompt so batch output stays machine-clean.
+            if (outputMode == OutputMode.NORMAL) {
+                console.print(prompt);
+                console.flush();
+            }
 
             String raw = reader.readLine();
             if (raw == null) {
@@ -883,7 +911,7 @@ public class JetShellTool {
                     } else if (ste.exception() instanceof UnresolvedReferenceException) {
                         printUnresolved((UnresolvedReferenceException) ste.exception());
                     } else {
-                        hard("Unexpected execution exception: %s", ste.exception());
+                        problem("Unexpected execution exception: %s", ste.exception());
                         return true;
                     }
                 } else {
@@ -891,13 +919,13 @@ public class JetShellTool {
                 }
             } else if (ste.status() == Status.REJECTED) {
                 if (diagnostics.isEmpty()) {
-                    hard("Failed.");
+                    problem("Failed.");
                 }
                 return true;
             }
         } else if (ste.status() == Status.REJECTED) {
             if (sn instanceof DeclarationSnippet) {
-                hard("Caused failure of dependent %s", ((DeclarationSnippet) sn).name());
+                problem("Caused failure of dependent %s", ((DeclarationSnippet) sn).name());
             }
             printDiagnostics(source, diagnostics);
             return true;
@@ -1000,10 +1028,10 @@ public class JetShellTool {
     private void printDiagnostics(String source, List<Diag> diagnostics) {
         for (Diag diag : diagnostics) {
             if (diag.isError()) {
-                hard("Error:");
+                problem("Error:");
             }
             for (String line : diag.getMessage(Locale.getDefault()).split("\\R")) {
-                hard("%s", line);
+                problem("%s", line);
             }
             int startPos = (int) diag.getStartPosition();
             int endPos = (int) diag.getEndPosition();
@@ -1015,12 +1043,12 @@ public class JetShellTool {
                 int lineEnd = lineMatcher.find(searchFrom) ? lineMatcher.start() : source.length();
                 String srcLine = source.substring(pos, lineEnd);
                 if (startPos >= pos && startPos <= lineEnd) {
-                    hard("%s", srcLine);
+                    problem("%s", srcLine);
                     StringBuilder sb = new StringBuilder();
                     for (int i = 0; i < srcLine.length(); i++) {
                         sb.append(i >= (startPos - pos) && i < (endPos - pos) ? '^' : ' ');
                     }
-                    hard("%s", sb.toString());
+                    problem("%s", sb.toString());
                     break;
                 }
                 if (lineEnd == source.length()) break;
@@ -1031,7 +1059,7 @@ public class JetShellTool {
     }
 
     private void printEvalException(EvalException ex) {
-        hard("Exception %s: %s", ex.getExceptionClassName(), ex.getMessage());
+        problem("Exception %s: %s", ex.getExceptionClassName(), ex.getMessage());
         for (StackTraceElement ste : ex.getStackTrace()) {
             StringBuilder sb = new StringBuilder();
             String cn = ste.getClassName();
@@ -1045,13 +1073,13 @@ public class JetShellTool {
             if (!ste.getMethodName().isEmpty()) {
                 sb.append(ste.getMethodName());
             }
-            hard("    at %s(%s:%d)", sb, ste.getFileName(), ste.getLineNumber());
+            problem("    at %s(%s:%d)", sb, ste.getFileName(), ste.getLineNumber());
         }
     }
 
     private void printUnresolved(UnresolvedReferenceException ex) {
         DeclarationSnippet sn = ex.getSnippet();
-        hard("Attempted to use %s which cannot be invoked until %s is declared",
+        problem("Attempted to use %s which cannot be invoked until %s is declared",
                 sn.name(), unresolved(sn));
     }
 
@@ -1600,6 +1628,12 @@ public class JetShellTool {
                         }
                         cmdlineStartup = "";
                         break;
+                    case "-plain":
+                        outputMode = OutputMode.PLAIN;
+                        break;
+                    case "-quiet":
+                        outputMode = OutputMode.QUIET;
+                        break;
                     case "-help":
                         printUsage();
                         return EARLY_EXIT;
@@ -1625,6 +1659,8 @@ public class JetShellTool {
         cmdout.printf("  -cp <path>                 Specify where to find user class files%n");
         cmdout.printf("  -startup <file>            One run replacement for the start-up definitions%n");
         cmdout.printf("  -nostartup                 Do not run the start-up definitions%n");
+        cmdout.printf("  -plain                     Drop the '|  ' prefix from batch output%n");
+        cmdout.printf("  -quiet                     Suppress informational output; errors go to stderr%n");
         cmdout.printf("  -help                      Print a synopsis of standard options%n");
         cmdout.printf("  -version                   Version information%n");
     }

--- a/src/test/java/net/unit8/jetshell/tool/PlainOutputTest.java
+++ b/src/test/java/net/unit8/jetshell/tool/PlainOutputTest.java
@@ -1,0 +1,82 @@
+package net.unit8.jetshell.tool;
+
+import net.unit8.jetshell.command.JetShellCommandRegister;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Issue #12: -plain drops the "|  " prefix from batch output; -quiet suppresses
+ * informational output entirely while still reporting errors on stderr.
+ */
+@Test
+public class PlainOutputTest {
+
+    private static class Result {
+        final String out;
+        final String err;
+        Result(String out, String err) {
+            this.out = out;
+            this.err = err;
+        }
+    }
+
+    private static Result run(String[] args, String script) throws Exception {
+        ByteArrayInputStream in = new ByteArrayInputStream(script.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream psOut = new PrintStream(out, true, StandardCharsets.UTF_8);
+        PrintStream psErr = new PrintStream(err, true, StandardCharsets.UTF_8);
+        JetShellTool tool = JetShellTool.create(in, psOut, psErr);
+        new JetShellCommandRegister().register(tool);
+        tool.testPrompt = true;
+        tool.start(args);
+        psOut.flush();
+        psErr.flush();
+        return new Result(out.toString(StandardCharsets.UTF_8), err.toString(StandardCharsets.UTF_8));
+    }
+
+    public void normalModeKeepsPrefix() throws Exception {
+        Result r = run(new String[0], "var x = 1 + 1;\n/exit\n");
+        assertTrue(r.out.contains("|  Added variable x of type int with initial value 2"),
+                "Normal mode must keep the '|  ' prefix. Output:\n" + r.out);
+    }
+
+    public void plainDropsPrefixOnStdout() throws Exception {
+        Result r = run(new String[]{"-plain"}, "var x = 1 + 1;\n/exit\n");
+        assertTrue(r.out.contains("Added variable x of type int with initial value 2"),
+                "Plain mode must still print the message. Output:\n" + r.out);
+        assertFalse(r.out.contains("|  "),
+                "Plain mode must drop the '|  ' prefix. Output:\n" + r.out);
+    }
+
+    public void plainDropsPrefixOnErrors() throws Exception {
+        Result r = run(new String[]{"-plain"}, "int y = \"nope\";\n/exit\n");
+        assertTrue(r.out.contains("Error:"),
+                "Plain mode still reports the error (on stdout, as today). Output:\n" + r.out);
+        assertFalse(r.out.contains("|  "),
+                "Plain mode must drop the '|  ' prefix from diagnostics. Output:\n" + r.out);
+    }
+
+    public void quietSuppressesInformationalOutput() throws Exception {
+        Result r = run(new String[]{"-quiet"}, "var x = 1 + 1;\n/exit\n");
+        assertTrue(r.out.isEmpty(),
+                "Quiet mode must produce no informational stdout. Output:\n" + r.out);
+    }
+
+    public void quietStillReportsErrorsOnStderr() throws Exception {
+        Result r = run(new String[]{"-quiet"}, "int y = \"nope\";\n/exit\n");
+        assertTrue(r.err.contains("Error:"),
+                "Quiet mode must still report errors on stderr. Stderr:\n" + r.err);
+        assertFalse(r.out.contains("Error:"),
+                "Quiet mode must not print errors on stdout. Stdout:\n" + r.out);
+        assertFalse(r.err.contains("|  "),
+                "Quiet mode stderr must have no '|  ' prefix. Stderr:\n" + r.err);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #12. The `|  ` prefix on every output line is helpful for interactive use but makes batch output awkward to consume with `grep`/`awk`/`diff`. This adds two CLI flags (single-dash, matching the existing `-startup`/`-nostartup` convention):

- **`-plain`** — drop the `|  ` prefix from informational **and** error output, and drop the `-> ` prompt. Lines are clean for downstream tooling.
- **`-quiet`** — suppress informational output entirely (banner, declarations, expression values) while still reporting snippet compile/runtime **errors on stderr**, so failures stay visible and the exit code is unaffected.

## Behaviour

```sh
$ echo 'var x = 1 + 1;' | jetshell -nostartup -plain
Added variable x of type int with initial value 2

$ echo 'var x = 1 + 1;' | jetshell -nostartup -quiet
# (no stdout)

$ echo 'int y = "nope";' | jetshell -nostartup -quiet
# stdout empty; stderr:
Error:
不適合な型: ...
int y = "nope";
        ^^^^^^
```

## Design

Output is routed through three helpers keyed off an `OutputMode { NORMAL, PLAIN, QUIET }` enum:

| helper | role | NORMAL | PLAIN | QUIET |
|--------|------|--------|-------|-------|
| `hard()` | informational | stdout + prefix | stdout | *(suppressed)* |
| `problem()` | snippet compile/runtime errors | stdout + prefix | stdout | **stderr** |
| `error()` | command/argument errors | stderr + prefix | stderr | stderr |

The `|  ` prefix is added only in NORMAL; the `-> ` prompt is emitted only in NORMAL. Diagnostics previously went through `hard()` (i.e. stdout); they now go through `problem()` so `-quiet` can keep them on stderr while silencing stdout — NORMAL/PLAIN keep the existing stdout behaviour, so nothing changes without a flag.

## Testing

- New `PlainOutputTest` (5 cases): normal keeps prefix, plain drops prefix on stdout and on errors, quiet suppresses stdout, quiet still reports errors on stderr.
- Full suite: **53 green**.
- Verified end-to-end against the built `target/jetshell` for all three modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)